### PR TITLE
Fix goimports install cmd on macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Set ``GOPATH``::
 If you install ``goimports`` in advance (recommend)::
 
   $ export PATH=${GOPATH}/bin:$PATH
-  $ go get code.google.com/p/go.tools/cmd/goimports
+  $ go get golang.org/x/tools/cmd/goimports
 
 Install the ``Gosh``::
 


### PR DESCRIPTION
Hi there,

The README goimports install command points to a package that no longer exists (`code.google.com/p/go.tools/cmd/goimports`). This updates to the correct one used by the code (` golang.org/x/tools/cmd/goimports`).